### PR TITLE
crdmigration: migrates crds to extensions v1 (PROJQUAY-2219)

### DIFF
--- a/deploy/crds/redhatcop_v1alpha1_quayintegration_crd.yaml
+++ b/deploy/crds/redhatcop_v1alpha1_quayintegration_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: quayintegrations.redhatcop.redhat.io
@@ -10,57 +10,57 @@ spec:
     plural: quayintegrations
     singular: quayintegration
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            blacklistNamespaces:
-              items:
-                type: string
-              type: array
-            clusterID:
-              type: string
-            credentialsSecretName:
-              type: string
-            insecureRegistry:
-              type: boolean
-            organizationPrefix:
-              type: string
-            quayHostname:
-              type: string
-            scheduledImageStreamImport:
-              type: boolean
-            whitelistNamespaces:
-              items:
-                type: string
-              type: array
-          required:
-          - clusterID
-          - credentialsSecretName
-          - quayHostname
-          type: object
-        status:
-          type: object
-          properties:
-            lastUpdate:
-              type: string
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              blacklistNamespaces:
+                items:
+                  type: string
+                type: array
+              clusterID:
+                type: string
+              credentialsSecretName:
+                type: string
+              insecureRegistry:
+                type: boolean
+              organizationPrefix:
+                type: string
+              quayHostname:
+                type: string
+              scheduledImageStreamImport:
+                type: boolean
+              whitelistNamespaces:
+                items:
+                  type: string
+                type: array
+            required:
+            - clusterID
+            - credentialsSecretName
+            - quayHostname
+            type: object
+          status:
+            type: object
+            properties:
+              lastUpdate:
+                type: string

--- a/deploy/manifests/quay-bridge-operator/1.0.0/quay-integration.crd.yaml
+++ b/deploy/manifests/quay-bridge-operator/1.0.0/quay-integration.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: quayintegrations.redhatcop.redhat.io
@@ -10,58 +10,57 @@ spec:
     plural: quayintegrations
     singular: quayintegration
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            blacklistNamespaces:
-              items:
-                type: string
-              type: array
-            clusterID:
-              type: string
-            credentialsSecretName:
-              type: string
-            insecureRegistry:
-              type: boolean
-            organizationPrefix:
-              type: string
-            quayHostname:
-              type: string
-            scheduledImageStreamImport:
-              type: boolean
-            whitelistNamespaces:
-              items:
-                type: string
-              type: array
-          required:
-          - clusterID
-          - credentialsSecretName
-          - quayHostname
-          type: object
-        status:
-          type: object
-          properties:
-            lastUpdate:
-              type: string
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              blacklistNamespaces:
+                items:
+                  type: string
+                type: array
+              clusterID:
+                type: string
+              credentialsSecretName:
+                type: string
+              insecureRegistry:
+                type: boolean
+              organizationPrefix:
+                type: string
+              quayHostname:
+                type: string
+              scheduledImageStreamImport:
+                type: boolean
+              whitelistNamespaces:
+                items:
+                  type: string
+                type: array
+            required:
+            - clusterID
+            - credentialsSecretName
+            - quayHostname
+            type: object
+          status:
+            type: object
+            properties:
+              lastUpdate:
+                type: string


### PR DESCRIPTION
v1beta1 is about to be unsupported by k8s.