### PR TITLE
upgrade: Upgrade certificates and admissionregistration to v1 (PROJQUAY-2532)

### DIFF
--- a/deploy/crds/redhatcop_v1alpha1_quayintegration_crd.yaml
+++ b/deploy/crds/redhatcop_v1alpha1_quayintegration_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: quayintegrations.redhatcop.redhat.io
@@ -10,57 +10,57 @@ spec:
     plural: quayintegrations
     singular: quayintegration
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            blacklistNamespaces:
-              items:
-                type: string
-              type: array
-            clusterID:
-              type: string
-            credentialsSecretName:
-              type: string
-            insecureRegistry:
-              type: boolean
-            organizationPrefix:
-              type: string
-            quayHostname:
-              type: string
-            scheduledImageStreamImport:
-              type: boolean
-            whitelistNamespaces:
-              items:
-                type: string
-              type: array
-          required:
-          - clusterID
-          - credentialsSecretName
-          - quayHostname
-          type: object
-        status:
-          type: object
-          properties:
-            lastUpdate:
-              type: string
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              blacklistNamespaces:
+                items:
+                  type: string
+                type: array
+              clusterID:
+                type: string
+              credentialsSecretName:
+                type: string
+              insecureRegistry:
+                type: boolean
+              organizationPrefix:
+                type: string
+              quayHostname:
+                type: string
+              scheduledImageStreamImport:
+                type: boolean
+              whitelistNamespaces:
+                items:
+                  type: string
+                type: array
+            required:
+            - clusterID
+            - credentialsSecretName
+            - quayHostname
+            type: object
+          status:
+            type: object
+            properties:
+              lastUpdate:
+                type: string

--- a/deploy/manifests/quay-bridge-operator/1.0.0/quay-bridge-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-bridge-operator/1.0.0/quay-bridge-operator.v1.0.0.clusterserviceversion.yaml
@@ -159,7 +159,7 @@ spec:
     Replace the `${CA_BUNDLE}` variable in the following `MutatingWebhookConfiguration` YAML and create it:
 
     ```yaml
-    apiVersion: admissionregistration.k8s.io/v1beta1
+    apiVersion: admissionregistration.k8s.io/v1
     kind: MutatingWebhookConfiguration 
     metadata:
       name: quay-bridge-operator
@@ -177,6 +177,10 @@ spec:
           apiVersions: ["v1" ]
           resources: [ "builds" ]
         failurePolicy: Fail
+        sideEffects: None
+        admissionReviewVersions: v1beta1
+        matchPolicy: Exact
+        timeoutSeconds: 30s
     ```
 
     _Note: Until the operator is running, new requests for builds will fail since the webserver the MutatingWebhookConfiguration invokes is not available and a proper is response is required in order for the object to be persisted in etcd._

--- a/deploy/manifests/quay-bridge-operator/1.0.0/quay-integration.crd.yaml
+++ b/deploy/manifests/quay-bridge-operator/1.0.0/quay-integration.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: quayintegrations.redhatcop.redhat.io
@@ -10,58 +10,57 @@ spec:
     plural: quayintegrations
     singular: quayintegration
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            blacklistNamespaces:
-              items:
-                type: string
-              type: array
-            clusterID:
-              type: string
-            credentialsSecretName:
-              type: string
-            insecureRegistry:
-              type: boolean
-            organizationPrefix:
-              type: string
-            quayHostname:
-              type: string
-            scheduledImageStreamImport:
-              type: boolean
-            whitelistNamespaces:
-              items:
-                type: string
-              type: array
-          required:
-          - clusterID
-          - credentialsSecretName
-          - quayHostname
-          type: object
-        status:
-          type: object
-          properties:
-            lastUpdate:
-              type: string
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              blacklistNamespaces:
+                items:
+                  type: string
+                type: array
+              clusterID:
+                type: string
+              credentialsSecretName:
+                type: string
+              insecureRegistry:
+                type: boolean
+              organizationPrefix:
+                type: string
+              quayHostname:
+                type: string
+              scheduledImageStreamImport:
+                type: boolean
+              whitelistNamespaces:
+                items:
+                  type: string
+                type: array
+            required:
+            - clusterID
+            - credentialsSecretName
+            - quayHostname
+            type: object
+          status:
+            type: object
+            properties:
+              lastUpdate:
+                type: string

--- a/deploy/mutatingwebhookconfiguration.yaml
+++ b/deploy/mutatingwebhookconfiguration.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration 
 metadata:
   name: quay-bridge-operator
@@ -16,3 +16,7 @@ webhooks:
       apiVersions: ["v1" ]
       resources: [ "builds" ]
     failurePolicy: Fail
+    matchPolicy: Exact
+    timeoutSeconds: 30s
+    sideEffects: None
+    admissionReviewVersions: v1beta1

--- a/hack/webhook-create-signed-cert.sh
+++ b/hack/webhook-create-signed-cert.sh
@@ -83,11 +83,12 @@ kubectl delete csr ${csrName} 2>/dev/null || true
 
 # create  server cert/key CSR and  send to k8s API
 cat <<EOF | kubectl create -f -
-apiVersion: certificates.k8s.io/v1beta1
+apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
   name: ${csrName}
 spec:
+  signerName: kubernetes.io/kubelet-serving
   groups:
   - system:authenticated
   request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')


### PR DESCRIPTION
- Upgrade certificates.k8s.io/v1beta1 to v1
- Upgrade admissionregistration.k8s.io/v1beta1 to v1
- Include fields where default values have been changed to preserve previous defaults
- Upgrade apiextensions to v1
