### PR TITLE
Add simple end-to-end test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,3 +141,7 @@ bundle: manifests kustomize
 .PHONY: bundle-build ## Build the bundle image.
 bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
+.PHONY: test-e2e
+test-e2e:
+	./hack/test-e2e.sh

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ Next, Deploy the operator to the cluster
 make deploy IMG=quay.io/quay/quay-bridge-operator:latest
 ```
 
+### End to End Testing
+
+Once you have an installed and configured Quay Bridge Operator on an OpenShift cluster, you can run end-to-end tests to verify that it works as expected
+
+```
+make test-e2e
+```
 
 ## End to End Demonstration
 

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -1,0 +1,45 @@
+#!/bin/sh -eu
+
+NAMESPACE=${NAMESPACE:-e2e-test}
+
+REGISTRY_ENDPOINT="$(oc get quayintegrations -o jsonpath='{.items[*].spec.quayHostname}')"
+REGISTRY="${REGISTRY_ENDPOINT#*://}"
+
+oc new-project "$NAMESPACE"
+
+# Wait until QBO creates a new project and secrets
+sleep 10
+oc -n "$NAMESPACE" get secrets builder-quay-openshift deployer-quay-openshift default-quay-openshift
+
+# Create a new build and check its results
+oc -n "$NAMESPACE" new-app --template=httpd-example
+i=0
+while [ $i -lt 120 ]; do
+    phase=$(oc -n "$NAMESPACE" get build httpd-example-1 -o jsonpath='{.status.phase}' || true)
+    if [ "$phase" != "" ] && [ "$phase" != "New" ] && [ "$phase" != "Pending" ] && [ "$phase" != "Running" ]; then
+        break
+    fi
+    sleep 1
+    i=$((i+1))
+done
+if [ "$phase" != "Complete" ]; then
+    echo "ERROR: The build httpd-example-1 is $phase, but expected to be Complete" >&2
+    set -x
+    oc -n "$NAMESPACE" get builds
+    oc -n "$NAMESPACE" get pods
+    oc -n "$NAMESPACE" logs httpd-example-1-build
+    exit 1
+fi
+
+IMAGE_REF=$(oc -n "$NAMESPACE" get is httpd-example -o jsonpath='{.status.tags[0].items[0].dockerImageReference}')
+case "$IMAGE_REF" in
+"$REGISTRY/"*)
+    ;;
+*)
+    echo "ERROR: The image $IMAGE_REF is expected to be in the registry $REGISTRY" >&2
+    set -x
+    oc -n "$NAMESPACE" get builds
+    oc -n "$NAMESPACE" get is httpd-example -o yaml
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
A simple script that checks that the installed Quay Bridge Operator on a cluster is functional.