### PR TITLE
csv: rename deployment (PROJQUAY-3239)

### DIFF
--- a/bundle/downstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
+++ b/bundle/downstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
@@ -567,9 +567,9 @@ spec:
                 - subjectaccessreviews
               verbs:
                 - create
-          serviceAccountName: quay-bridge-operator-controller-manager
+          serviceAccountName: quay-bridge-operator
       deployments:
-        - name: quay-bridge-operator-controller-manager
+        - name: quay-bridge-operator
           spec:
             replicas: 1
             selector:
@@ -632,7 +632,7 @@ spec:
                         readOnly: true
                 securityContext:
                   runAsNonRoot: true
-                serviceAccountName: quay-bridge-operator-controller-manager
+                serviceAccountName: quay-bridge-operator
                 terminationGracePeriodSeconds: 10
                 volumes:
                   - name: apiservice-cert
@@ -667,7 +667,7 @@ spec:
               verbs:
                 - create
                 - patch
-          serviceAccountName: quay-bridge-operator-controller-manager
+          serviceAccountName: quay-bridge-operator
     strategy: deployment
   installModes:
     - supported: false
@@ -696,7 +696,7 @@ spec:
     - admissionReviewVersions:
         - v1
       containerPort: 443
-      deploymentName: quay-bridge-operator-controller-manager
+      deploymentName: quay-bridge-operator
       failurePolicy: Fail
       generateName: quayintegration.quay.redhat.com
       rules:

--- a/bundle/upstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
+++ b/bundle/upstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
@@ -218,9 +218,9 @@ spec:
                 - subjectaccessreviews
               verbs:
                 - create
-          serviceAccountName: quay-bridge-operator-controller-manager
+          serviceAccountName: quay-bridge-operator
       deployments:
-        - name: quay-bridge-operator-controller-manager
+        - name: quay-bridge-operator
           spec:
             replicas: 1
             selector:
@@ -283,7 +283,7 @@ spec:
                         readOnly: true
                 securityContext:
                   runAsNonRoot: true
-                serviceAccountName: quay-bridge-operator-controller-manager
+                serviceAccountName: quay-bridge-operator
                 terminationGracePeriodSeconds: 10
                 volumes:
                   - name: apiservice-cert
@@ -318,7 +318,7 @@ spec:
               verbs:
                 - create
                 - patch
-          serviceAccountName: quay-bridge-operator-controller-manager
+          serviceAccountName: quay-bridge-operator
     strategy: deployment
   installModes:
     - supported: false
@@ -347,7 +347,7 @@ spec:
     - admissionReviewVersions:
         - v1
       containerPort: 443
-      deploymentName: quay-bridge-operator-controller-manager
+      deploymentName: quay-bridge-operator
       failurePolicy: Fail
       generateName: quayintegration.quay.redhat.com
       rules:


### PR DESCRIPTION
On v3.6.3 the selectors have changed. Selectors are, according to OLM,
an immutable field therefore we need to rename the deployment.

By renaming the deployment OLM will delete the previous deployment and
create a new one:

https://github.com/operator-framework/operator-lifecycle-manager/issues/952#issuecomment-639657949