### PR TITLE
fix: nil check http response when err is not nil (PROJQUAY-6620)

### DIFF
--- a/controllers/namespace_controller.go
+++ b/controllers/namespace_controller.go
@@ -313,6 +313,15 @@ func (r *NamespaceIntegrationReconciler) setupResources(ctx context.Context, req
 		// Check if Repository Exists
 		_, repositoryHttpResponse, repositoryErr := quayClient.GetRepository(quayOrganizationName, imageStreamName)
 
+		if repositoryHttpResponse == nil {
+			return r.CoreComponents.ManageError(&core.QuayIntegrationCoreError{
+				Object:       namespace,
+				Message:      "Error creating request to retrieve repository",
+				KeyAndValues: []interface{}{"Namespace", namespace.Name, "Name", imageStreamName},
+				Error:        repositoryErr.Error,
+			})
+		}
+
 		if repositoryErr.Error != nil {
 			return r.CoreComponents.ManageError(&core.QuayIntegrationCoreError{
 				Object:       namespace,


### PR DESCRIPTION
Topic: [projquay-6507](https://issues.redhat.com//browse/projquay-6507)

The operator was panicking due to the httpResponse being nil and attempting to return the httpResponse.StatusCode in the response; the response was most likely nil due to a prior error when attempting to marshal json and build the http request itself. This now allows the error to be propagated out to the logs instead of causing the operator to panic

Signed-off-by: Ross Bryan <robryan@redhat.com>