### PR TITLE
chore: remove reflection zero type when zero value is known (PROJQUAY-6620)

### DIFF
--- a/pkg/client/quay/client.go
+++ b/pkg/client/quay/client.go
@@ -8,8 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-
-	"github.com/quay/quay-bridge-operator/pkg/utils"
 )
 
 type QuayClient struct {
@@ -172,7 +170,7 @@ func (c *QuayClient) newRequest(method, path string, body interface{}) (*http.Re
 	}
 
 	req, err := http.NewRequest(method, u.String(), buf)
-	if !utils.IsZeroOfUnderlyingType(c.AuthToken) {
+	if c.AuthToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.AuthToken)
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,16 +2,11 @@ package utils
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/quay/quay-bridge-operator/pkg/constants"
 	"github.com/quay/quay-bridge-operator/pkg/logging"
 	corev1 "k8s.io/api/core/v1"
 )
-
-func IsZeroOfUnderlyingType(x interface{}) bool {
-	return reflect.DeepEqual(x, reflect.Zero(reflect.TypeOf(x)).Interface())
-}
 
 func RemoveItemsFromSlice(s []string, r []string) []string {
 


### PR DESCRIPTION
reflection uses unsafe types and is cpu intensive. we can reduce cpu
cycles on every api call by simple comparing an empty strings equality
to the value of the AuthToken.

strings.EqualFold is a std lib solution that provides similar
functionality, but that is not necessary for comparing empty strings as
it simply uses the standard equality operator as well

Topic: rm-reflection

Relative: [projquay-6620](https://issues.redhat.com//browse/projquay-6620)
Signed-off-by: Ross Bryan <robryan@redhat.com>