### PR TITLE
docs: add AI agent documentation with progressive disclosure (PROJQUAY-9897)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,16 +21,16 @@ Syncs namespaces as Quay organizations, manages robot accounts, rewrites builds 
 
 Read the specific documentation below if your task involves these keywords:
 
-- **Controllers, CRD, Webhook, Reconciler, Finalizer** -> `read_file agent_docs/architecture.md`
+- **Controllers, CRD, Webhook, Reconciler, Finalizer** -> `read file agent_docs/architecture.md`
   - **CRITICAL**: Understand the three-controller design before modifying reconciliation logic.
 
-- **Build, Test, Deploy, Run, Make, Docker** -> `read_file agent_docs/development.md`
+- **Build, Test, Deploy, Run, Make, Docker** -> `read file agent_docs/development.md`
   - **CRITICAL**: Use `make test` for full test suite with envtest setup.
 
-- **Quay, API, Organization, Robot, Repository, Prototype** -> `read_file agent_docs/quay-api.md`
+- **Quay, API, Organization, Robot, Repository, Prototype** -> `read file agent_docs/quay-api.md`
   - **CRITICAL**: All Quay client methods return (result, *http.Response, error) tuple.
 
-- **Commit, PR, Jira, Contribution** -> `read_file agent_docs/contributing.md`
+- **Commit, PR, Jira, Contribution** -> `read file agent_docs/contributing.md`
   - **CRITICAL**: All changes require a PROJQUAY Jira reference.
 
 ## Key Files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# Quay Bridge Operator - Agent Context
+
+## Project Overview
+Kubernetes operator integrating Red Hat Quay container registry with OpenShift.
+Syncs namespaces as Quay organizations, manages robot accounts, rewrites builds to push to Quay.
+
+## Tech Stack
+- **Language**: Go 1.21+
+- **Framework**: Kubebuilder v3, controller-runtime
+- **APIs**: OpenShift Build/Image APIs, Quay REST API
+- **Infra**: Kubernetes, cert-manager (for webhook TLS)
+
+## Core Workflow
+- **Build**: `make build`
+- **Test**: `make test`
+- **Lint**: `make fmt && make vet`
+- **Run locally**: `make run`
+- **Deploy**: `make deploy IMG=<image>`
+
+## Documentation Map
+
+Read the specific documentation below if your task involves these keywords:
+
+- **Controllers, CRD, Webhook, Reconciler, Finalizer** -> `read_file agent_docs/architecture.md`
+  - **CRITICAL**: Understand the three-controller design before modifying reconciliation logic.
+
+- **Build, Test, Deploy, Run, Make, Docker** -> `read_file agent_docs/development.md`
+  - **CRITICAL**: Use `make test` for full test suite with envtest setup.
+
+- **Quay, API, Organization, Robot, Repository, Prototype** -> `read_file agent_docs/quay-api.md`
+  - **CRITICAL**: All Quay client methods return (result, *http.Response, error) tuple.
+
+- **Commit, PR, Jira, Contribution** -> `read_file agent_docs/contributing.md`
+  - **CRITICAL**: All changes require a PROJQUAY Jira reference.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `api/v1/quayintegration_types.go` | QuayIntegration CRD definition |
+| `controllers/namespace_controller.go` | Main integration logic |
+| `controllers/build_controller.go` | Post-build image import |
+| `pkg/webhook/webhook.go` | Build mutation webhook |
+| `pkg/client/quay/client.go` | Quay API client |
+| `config/samples/quay_v1_quayintegration.yaml` | Example CR |
+
+## Universal Conventions
+- **Style**: Follow existing Go idioms, use controller-runtime patterns
+- **Testing**: Mocks in `pkg/client/quay/mocks/`, use envtest for controller tests
+- **Safety**: Never commit secrets; webhook requires TLS certificates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,3 @@
+# GEMINI
+
+Please follow instructions from @./AGENTS.md

--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -1,0 +1,75 @@
+# Architecture
+
+## Custom Resource
+
+The operator manages a single cluster-scoped CRD:
+
+**QuayIntegration** (`api/v1/quayintegration_types.go`): Configures connection to Quay registry.
+
+Key fields:
+- `clusterID`: Unique identifier for this cluster (used in organization naming)
+- `quayHostname`: Full URL to Quay registry
+- `credentialsSecret`: Reference to secret containing OAuth token
+- `insecureRegistry`: Skip TLS verification
+- `scheduledImageStreamImport`: Enable scheduled imports
+- `allowlistNamespaces` / `denylistNamespaces`: Namespace filtering
+
+## Controllers
+
+Three reconcilers in `controllers/`:
+
+### QuayIntegrationReconciler
+- File: `quayintegration_controller.go`
+- Watches: `QuayIntegration` CR
+- Purpose: Validates configuration changes
+
+### NamespaceIntegrationReconciler
+- File: `namespace_controller.go`
+- Watches: `Namespace`, `ImageStream`
+- Purpose: Main integration logic
+  - Creates Quay organizations for allowed namespaces
+  - Creates robot accounts with role-based permissions
+  - Generates Docker config secrets
+  - Attaches secrets to service accounts
+  - Uses finalizer to clean up Quay organizations on namespace deletion
+
+### BuildIntegrationReconciler
+- File: `build_controller.go`
+- Watches: `Build` (completed builds with operator annotations)
+- Purpose: Imports pushed images back into OpenShift ImageStreams
+
+## Mutating Webhook
+
+File: `pkg/webhook/webhook.go`
+
+Intercepts Build creation/updates:
+1. Rewrites output from `ImageStreamTag` to `DockerImage` pointing at Quay
+2. Adds tracking annotations for BuildIntegrationReconciler
+3. Validates builder service account has required secrets
+
+## Service Account Permission Matrix
+
+OpenShift SA -> Quay Robot Role:
+- `builder` -> write (push images)
+- `default` -> read (pull images)
+- `deployer` -> read (pull images)
+
+## Key Packages
+
+| Package | Purpose |
+|---------|---------|
+| `pkg/client/quay/` | HTTP client for Quay REST API |
+| `pkg/core/` | Shared controller utilities, error handling |
+| `pkg/credentials/` | Docker config JSON secret generation |
+| `pkg/constants/` | Annotation keys, env vars, defaults |
+| `pkg/utils/` | Helpers for secret names, namespace validation |
+
+## Namespace Filtering
+
+Default denied namespaces (hardcoded):
+- `default`, `openshift`, `management-infra`
+- Any namespace starting with `openshift-` or `kube-`
+
+Override via CR:
+- `allowlistNamespaces`: Explicitly include (overrides default deny)
+- `denylistNamespaces`: Explicitly exclude

--- a/agent_docs/contributing.md
+++ b/agent_docs/contributing.md
@@ -1,0 +1,33 @@
+# Contributing
+
+## Requirements
+
+- All changes require a referenced [PROJQUAY Jira](https://issues.redhat.com/projects/PROJQUAY/issues)
+- Fork the repository and create a topic branch from `master`
+
+## Commit Message Format
+
+```
+<subsystem>: <what changed> (PROJQUAY-####)
+
+<why this change was made>
+```
+
+Example:
+```
+controllers: fix namespace finalizer race condition (PROJQUAY-1234)
+
+The finalizer was being removed before cleanup completed,
+causing orphaned Quay organizations.
+```
+
+Guidelines:
+- Subject line: max 70 characters
+- Body: wrap at 80 characters
+- Explain the "why", not just the "what"
+
+## Contact
+
+- Issues: [PROJQUAY Jira](https://issues.redhat.com/projects/PROJQUAY/issues)
+- Email: [quay-sig@googlegroups.com](https://groups.google.com/g/quay-sig)
+- IRC: #quay on freenode.org

--- a/agent_docs/development.md
+++ b/agent_docs/development.md
@@ -1,0 +1,89 @@
+# Development
+
+## Building
+
+```bash
+# Build manager binary
+make build
+
+# Run controller locally (requires kubeconfig)
+make run
+
+# Build Docker image
+make docker-build IMG=quay.io/quay/quay-bridge-operator:latest
+
+# Push Docker image
+make docker-push IMG=quay.io/quay/quay-bridge-operator:latest
+```
+
+## Code Generation
+
+```bash
+# Generate CRDs, RBAC, and webhook manifests
+make manifests
+
+# Generate DeepCopy methods and mocks
+make generate
+
+# Install mockgen tool
+make mockgen
+```
+
+## Testing
+
+```bash
+# Run all tests with coverage
+make test
+
+# Run specific test file
+go test ./pkg/client/quay/... -v
+
+# Run specific test function
+go test ./pkg/client/quay/... -v -run TestClientGetOrganization
+
+# Run e2e tests (requires operator running on OpenShift)
+make test-e2e
+```
+
+## Code Quality
+
+```bash
+# Format code
+make fmt
+
+# Run go vet
+make vet
+```
+
+## Deployment
+
+```bash
+# Install CRDs to cluster
+make install
+
+# Uninstall CRDs
+make uninstall
+
+# Deploy operator
+make deploy IMG=quay.io/quay/quay-bridge-operator:latest
+
+# Undeploy operator
+make undeploy
+
+# Generate OLM bundle
+make bundle
+```
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `DISABLE_WEBHOOK` | Set to disable mutating webhook |
+| `WEBHOOK_CERT_DIR` | Override webhook certificate directory |
+
+## Webhook Setup
+
+The webhook requires TLS certificates. In development:
+1. Deploy cert-manager via OLM
+2. Create a `Certificate` resource
+3. Certificates default to `/apiserver.local.config/certificates/`

--- a/agent_docs/quay-api.md
+++ b/agent_docs/quay-api.md
@@ -1,0 +1,58 @@
+# Quay API Client
+
+## Location
+`pkg/client/quay/`
+
+## Client Initialization
+
+```go
+quayClient := qclient.NewClient(&http.Client{
+    Transport: &http.Transport{
+        TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+    },
+}, quayHostname, authToken)
+```
+
+## Available Operations
+
+### Organizations
+- `GetOrganizationByName(name)` - Check if org exists
+- `CreateOrganization(name)` - Create new org
+- `DeleteOrganization(name)` - Delete org and all contents
+
+### Robot Accounts
+- `GetOrganizationRobotAccount(org, name)` - Get robot account
+- `CreateOrganizationRobotAccount(org, name)` - Create robot account
+
+### Repositories
+- `GetRepository(org, name)` - Check if repo exists
+- `CreateRepository(org, name)` - Create new repo
+
+### Prototypes (Default Permissions)
+- `GetPrototypesByOrganization(org)` - List permission prototypes
+- `CreateRobotPermissionForOrganization(org, robot, role)` - Add prototype
+
+## Response Handling
+
+All methods return three values:
+1. Response object (typed)
+2. `*http.Response` for status code checks
+3. Error object with `.Error` field
+
+Example pattern:
+```go
+org, response, err := quayClient.GetOrganizationByName(name)
+if err.Error != nil {
+    // Handle error
+}
+if response.StatusCode == 404 {
+    // Organization doesn't exist
+}
+```
+
+## Roles
+- `QuayRoleRead` - Pull access
+- `QuayRoleWrite` - Push access
+
+## Testing
+Mocks available in `pkg/client/quay/mocks/client_mock.go`


### PR DESCRIPTION
## Summary
- Adds structured documentation for AI coding agents (Claude Code, Gemini CLI)
- Follows progressive disclosure principles to minimize context while maximizing discoverability
- Creates shared `AGENTS.md` with keyword-based pointers to detailed docs in `agent_docs/`

## File Structure
```
CLAUDE.md           -> Points to @AGENTS.md
GEMINI.md           -> Points to @./AGENTS.md  
AGENTS.md           -> Main context (~50 lines) with documentation map
agent_docs/
  ├── architecture.md   -> Controllers, CRD, webhook details
  ├── development.md    -> Build, test, deploy commands
  ├── quay-api.md       -> Quay API client usage
  └── contributing.md   -> Commit format, Jira requirements
```

## Test plan
- [ ] Verify CLAUDE.md is loaded by Claude Code when opening the repository
- [ ] Verify agents can follow pointers to load detailed docs when needed
- [ ] Review documentation accuracy against current codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)