### PR TITLE
Add NetworkPolicy RBAC to satisfy Conforma olm.required_network_policy_rbac_for_operands

### DIFF
--- a/bundle/downstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
+++ b/bundle/downstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
@@ -580,6 +580,15 @@ spec:
                 - subjectaccessreviews
               verbs:
                 - create
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - update
+                - patch
           serviceAccountName: quay-bridge-operator
       deployments:
         - name: quay-bridge-operator

--- a/bundle/upstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
+++ b/bundle/upstream/manifests/quay-bridge-operator.clusterserviceversion.yaml
@@ -231,6 +231,15 @@ spec:
                 - subjectaccessreviews
               verbs:
                 - create
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - update
+                - patch
           serviceAccountName: quay-bridge-operator
       deployments:
         - name: quay-bridge-operator


### PR DESCRIPTION
## What

Adds a `clusterPermissions` rule to the ClusterServiceVersion granting
`create`, `delete`, `update`, `patch` on `networking.k8s.io/networkpolicies`
for the `quay-bridge-operator` service account, in both the downstream
(Konflux-built) and upstream (community-operators) bundle manifests.

## Why

A new Enterprise Contract (Conforma) policy rule,
[`olm.required_network_policy_rbac_for_operands`](https://conforma.dev/docs/policy/packages/release_olm.html#olm__required_network_policy_rbac_for_operands),
became effective org-wide on **2026-08-07**. It requires every OLM operator
bundle's CSV to declare RBAC for managing NetworkPolicy lifecycle for its
operands, and started failing Quay's operator bundle releases (first hit
during the Quay 3.18.1 z-stream release, which also affected quay-operator
and container-security-operator bundles the same way -- see
quay/quay-operator#1319).

The operator does not currently create NetworkPolicy objects itself; this is
a forward-looking compliance grant with no behavior change, matching the
policy's stated intent ("operators are required to manage the network
policies of their operands").

## Rollout plan

This targets `master` first. Once merged, it should be cherry-picked to the
active `redhat-3.1x` release branches as their z-stream releases come up, so
each active y-stream stops failing this Conforma check on its next bundle
release. Starting with 3.18.x since that's the release currently blocked.