### PR TITLE
PROJQUAY-11653: feat: Add default network policies for all components

### DIFF
--- a/bundle/downstream/manifests/quay-bridge-operator-quay-bridge-operator-netpol_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/downstream/manifests/quay-bridge-operator-quay-bridge-operator-netpol_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,54 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: quay-bridge-operator-quay-bridge-operator-netpol
+spec:
+  podSelector:
+    matchLabels:
+      name: quay-bridge-operator
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  # Kube API server
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  # Egress traffic to Quay instance (can live inside and outside of the cluster)
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 80
+  # DNS resolution: needs to be opened towards everyone to properly resolve Quay instances
+  # outside of the cluster where QBO is deployed
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+  ingress:
+  # Prometheus metrics scraping
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 8443
+  # Webhook access and health probes: no explicit from selector since these
+  # might come from host-network sources (kube-apiserver, kubelet)
+  - from:
+    ports:
+    - protocol: TCP
+      port: 9443
+    - protocol: TCP
+      port: 8081

--- a/bundle/upstream/manifests/quay-bridge-operator-quay-bridge-operator-netpol_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/upstream/manifests/quay-bridge-operator-quay-bridge-operator-netpol_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,54 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: quay-bridge-operator-quay-bridge-operator-netpol
+spec:
+  podSelector:
+    matchLabels:
+      name: quay-bridge-operator
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  # Kube API server
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  # Egress traffic to Quay instance (can live inside and outside of the cluster)
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 80
+  # DNS resolution: needs to be opened towards everyone to properly resolve Quay instances
+  # outside of the cluster where QBO is deployed
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+  ingress:
+  # Prometheus metrics scraping
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 8443
+  # Webhook access and health probes: no explicit from selector since these
+  # might come from host-network sources (kube-apiserver, kubelet)
+  - from:
+    ports:
+    - protocol: TCP
+      port: 9443
+    - protocol: TCP
+      port: 8081

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -21,8 +21,10 @@ bases:
   - ../webhook
   # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
   - ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+  # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+  #- ../prometheus
+  # Default network policy: to enable, uncomment the following line
+  # - ../networkpolicy
 
 patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.

--- a/config/networkpolicy/kustomization.yaml
+++ b/config/networkpolicy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - networkpolicy.yaml

--- a/config/networkpolicy/networkpolicy.yaml
+++ b/config/networkpolicy/networkpolicy.yaml
@@ -1,0 +1,54 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: quay-bridge-operator-netpol
+spec:
+  podSelector:
+    matchLabels:
+      name: quay-bridge-operator
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  # Kube API server
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  # Egress traffic to Quay instance (can live inside and outside of the cluster)
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 80
+  # DNS resolution: needs to be opened towards everyone to properly resolve Quay instances
+  # outside of the cluster where QBO is deployed
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+  ingress:
+  # Prometheus metrics scraping
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 8443
+  # Webhook access and health probes: no explicit from selector since these
+  # might come from host-network sources (kube-apiserver, kubelet)
+  - from:
+    ports:
+    - protocol: TCP
+      port: 9443
+    - protocol: TCP
+      port: 8081


### PR DESCRIPTION
This PR adds default network policies for the Quay Bridge Operator.